### PR TITLE
Fix portable symbols package

### DIFF
--- a/UserConfigMigrator/UserConfigMigrator.csproj
+++ b/UserConfigMigrator/UserConfigMigrator.csproj
@@ -7,9 +7,9 @@
     <Product>UserConfigMigrator</Product>
     <Description>Helper for migrating user-scoped .NET application settings across versions.</Description>
     <Copyright>Copyright ©  2025</Copyright>
-    <Version>1.3.0.0</Version>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <Version>1.3.1.0</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <Authors>Aleksander Ivanovski</Authors>
     <PackageId>UserConfigMigrator</PackageId>


### PR DESCRIPTION
Changed the type of generated code debugging symbols to `portable` (cross platform).