### PR TITLE
Fix search for net5.0 and higher

### DIFF
--- a/UserConfigMigrator/UserConfigMigrator.cs
+++ b/UserConfigMigrator/UserConfigMigrator.cs
@@ -127,13 +127,13 @@ namespace UserConfigMigration
                 $"Either '{nameof(app_info.Company)}' or '{nameof(app_info.RootNamespace)}' must be defined in '{nameof(AppInfo)}'");
         }
 
-        private static string FindLatestUserConfigFile(
+        private static UserConfigInfo FindLatestUserConfigFile(
             string app_data_dir,
             List<AppInfo> app_infos,
             Version current_app_version,
             bool accept_higher_app_versions)
         {
-            Version latest_version = null;
+            Version latest_user_config_version = null;
             string latest_user_config_path = null;
             foreach (AppInfo app_info in app_infos)
             {
@@ -178,15 +178,19 @@ namespace UserConfigMigration
                         {
                             continue;
                         }
-                        if ((latest_version == null) || (version > latest_version))
+                        if ((latest_user_config_version == null) || (version > latest_user_config_version))
                         {
-                            latest_version = version;
+                            latest_user_config_version = version;
                             latest_user_config_path = user_config_file;
                         }
                     }
                 }
             }
-            return latest_user_config_path;
+            if (latest_user_config_path == null)
+            {
+                return null;
+            }
+            return new UserConfigInfo(latest_user_config_path, latest_user_config_version);
         }
 
         private static void DebugLog(string line)

--- a/UserConfigMigrator/UserConfigMigrator.cs
+++ b/UserConfigMigrator/UserConfigMigrator.cs
@@ -131,7 +131,8 @@ namespace UserConfigMigration
             string app_data_dir,
             List<AppInfo> app_infos,
             Version current_app_version,
-            bool accept_higher_app_versions)
+            bool accept_higher_app_versions,
+            bool accept_same_app_version)
         {
             Version latest_user_config_version = null;
             string latest_user_config_path = null;
@@ -170,7 +171,7 @@ namespace UserConfigMigration
                         {
                             continue;
                         }
-                        if (version == current_app_version)
+                        if (!accept_same_app_version && (version == current_app_version))
                         {
                             continue;
                         }

--- a/UserConfigMigrator/UserConfigMigrator.cs
+++ b/UserConfigMigrator/UserConfigMigrator.cs
@@ -80,8 +80,8 @@ namespace UserConfigMigration
 
         private static string GetAssemblyName(string assembly_dir_name)
         {
-            // Indicator of assembly directory name is ".exe_Url_" in the middle of the assembly name.
-            const string indicator = ".exe_Url_";
+            // Indicator of assembly directory name is "_Url_" in the middle of the assembly name.
+            const string indicator = "_Url_";
             int indicator_start_index = assembly_dir_name.LastIndexOf(indicator, StringComparison.OrdinalIgnoreCase);
             if (indicator_start_index < 0)
             {

--- a/UserConfigMigrator/UserConfigMigrator.cs
+++ b/UserConfigMigrator/UserConfigMigrator.cs
@@ -348,6 +348,45 @@ namespace UserConfigMigration
         }
 
         /// <summary>
+        /// Represents user configuration file information.
+        /// </summary>
+        public class UserConfigInfo
+        {
+            /// <summary>
+            /// The path to the user configuration file.
+            /// </summary>
+            public string UserConfigPath { get; } = null;
+
+            /// <summary>
+            /// The version of the user configuration file.
+            /// </summary>
+            public Version UserConfigVersion { get; } = null;
+
+            /// <summary>
+            /// Make a new user configuration information instance.
+            /// </summary>
+            /// <param name="user_config_path">The path to the user configuration file.</param>
+            /// <param name="user_config_version">The version of the user configuration file.</param>
+            /// <exception cref="ArgumentException"></exception>
+            /// <exception cref="ArgumentNullException"></exception>
+            public UserConfigInfo(string user_config_path, Version user_config_version)
+            {
+                ValidatePath(user_config_path, nameof(user_config_path));
+                if (!user_config_path.EndsWith(
+                    Path.Combine("", USER_CONFIG_FILENAME), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException($"'{user_config_path}' must end with '{USER_CONFIG_FILENAME}'");
+                }
+                if (user_config_version == null)
+                {
+                    throw new ArgumentNullException(nameof(user_config_version));
+                }
+                UserConfigPath = user_config_path;
+                UserConfigVersion = user_config_version ?? throw new ArgumentNullException(nameof(user_config_version));
+            }
+        }
+
+        /// <summary>
         /// Find the latest user configuration file stored in local application settings.
         /// </summary>
         /// <param name="current_app_version">The current application version.</param>

--- a/UserConfigMigrator/UserConfigMigrator.csproj
+++ b/UserConfigMigrator/UserConfigMigrator.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'($TargetFramework)' != 'net48' And '$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.5" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />

--- a/UserConfigMigrator/UserConfigMigrator.csproj
+++ b/UserConfigMigrator/UserConfigMigrator.csproj
@@ -7,9 +7,9 @@
     <Product>UserConfigMigrator</Product>
     <Description>Helper for migrating user-scoped .NET application settings across versions.</Description>
     <Copyright>Copyright ©  2025</Copyright>
-    <Version>1.4.1.0</Version>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
+    <Version>1.4.2.0</Version>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <FileVersion>1.4.2.0</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <Authors>Aleksander Ivanovski</Authors>
     <PackageId>UserConfigMigrator</PackageId>


### PR DESCRIPTION
From .NET 5.0 and above, the assembly extension has been removed from the assembly directory name.

- Search for user configuration file by assembly name (without extension) to be compatible with all .NET versions.
- Search for user configuration file for same app version only if no other file is found (allows for moving stand-alone apps).